### PR TITLE
Remove HDOP

### DIFF
--- a/location.go
+++ b/location.go
@@ -38,12 +38,12 @@ var gpsKeyRegexp = regexp.MustCompile(`^gps_\d+$`)
 //   - latitudeDeg, longitudeDeg, height
 //   - gps_lat, gps_lng, gps_alt
 //   - gps_lat, gps_lng, gpsalt
-// And the following keys for accuracy:
+// And the following keys for accuracy in metres:
 //   - acc
 //   - accuracy
 //   - hacc
-//   - hdop
-//   - gps_hdop
+//
+// HDOP and satellite count are currently not used.
 //
 // All numeric values are assumed to be float64.
 //
@@ -101,13 +101,11 @@ func InferLocation(m map[string]interface{}) (res Location, ok bool) {
 	}
 
 	if ok {
-		// Check accuracy in fields. Horizontal dilution of precision is considered accuracy.
+		// Check accuracy in fields.
 		for _, ap := range []string{
 			"acc",
 			"accuracy",
-			"hacc",
-			"hdop",
-			"gps_hdop",
+			"hacc", // horizontal accuracy
 		} {
 			acc, hasAcc := m[ap].(float64)
 			if hasAcc {


### PR DESCRIPTION
For now let's not parse the hdop value and put it into the accuracy field. Accuracy is assumed to be an accuracy in metres. HDOP is a unitless indicator of the accuracy. An accuracy of 3 metres is good, while an HDOP of 3 is quite bad.

Estimating an accuracy in metres form HDOP is possible, but that should be left to the (user) payload decoder to do, and keep this parser clean without any magic.
Ref: https://www.gps-forums.com/threads/roughtly-converting-dop-to-metric-error.40105/#post-206314