### PR TITLE
Validate locations upon inference

### DIFF
--- a/location_test.go
+++ b/location_test.go
@@ -4,6 +4,7 @@
 package apppayload_test
 
 import (
+	"math"
 	"strconv"
 	"testing"
 
@@ -70,6 +71,24 @@ func TestInferLocation(t *testing.T) {
 				Accuracy:  4,
 			},
 			ok: true,
+		},
+		{
+			m: map[string]interface{}{
+				"latitude":  math.NaN(),
+				"longitude": float64(2),
+				"altitude":  float64(3),
+				"accuracy":  float64(4),
+			},
+			ok: false,
+		},
+		{
+			m: map[string]interface{}{
+				"latitude":  float64(1),
+				"longitude": float64(200),
+				"altitude":  float64(3),
+				"accuracy":  float64(4),
+			},
+			ok: false,
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {


### PR DESCRIPTION
References https://github.com/TheThingsIndustries/protoc-gen-go-json/pull/1
References https://github.com/TheThingsNetwork/lorawan-stack/pull/4827

Locations inferred by this package may be fooled by `NaN`s or `Infinity` values, which can occur when the payload decoder attempts to decode bytes which are not present. These values are there, are not `0`, so they were previously also considered valid.

cc @jpmeijers 