### PR TITLE
Add GNSS and WiFi access points inference

### DIFF
--- a/gnss.go
+++ b/gnss.go
@@ -1,0 +1,35 @@
+// Copyright © 2022 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package apppayload
+
+import "encoding/hex"
+
+// InferGNSS uses a predefined set of rules in order to infer
+// a GNSS payload from the provided map.
+//
+// The following keys are checked for hexadecimal payloads:
+// - nav
+//
+// If no GNSS payload can be inferred, this function returns false.
+func InferGNSS(m map[string]interface{}) ([]byte, bool) {
+	if len(m) == 0 {
+		return nil, false
+	}
+
+	for _, key := range []string{
+		"nav",
+	} {
+		s, ok := m[key].(string)
+		if !ok {
+			continue
+		}
+		b, err := hex.DecodeString(s)
+		if err != nil {
+			continue
+		}
+		return b, true
+	}
+
+	return nil, false
+}

--- a/gnss_test.go
+++ b/gnss_test.go
@@ -1,0 +1,55 @@
+// Copyright © 2021 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package apppayload_test
+
+import (
+	"reflect"
+	"testing"
+
+	apppayload "go.thethings.network/lorawan-application-payload"
+)
+
+func TestGNSSInference(t *testing.T) {
+	for _, tc := range []struct {
+		Name   string
+		Input  map[string]interface{}
+		Output []byte
+		Ok     bool
+	}{
+		{
+			Name: "ValidPayload",
+			Input: map[string]interface{}{
+				"nav": "aabbccdd",
+			},
+			Output: []byte{0xaa, 0xbb, 0xcc, 0xdd},
+			Ok:     true,
+		},
+		{
+			Name: "InvalidPayload",
+			Input: map[string]interface{}{
+				"nav": "aabbccddgg",
+			},
+			Ok: false,
+		},
+		{
+			Name: "NoKey",
+			Input: map[string]interface{}{
+				"gnss": "aabbccdd",
+			},
+			Ok: false,
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			points, ok := apppayload.InferGNSS(tc.Input)
+			if tc.Ok != ok {
+				t.Fatal("Expected access points not found")
+			}
+			if tc.Ok {
+				if !reflect.DeepEqual(tc.Output, points) {
+					t.Fatal("Output mismatch")
+				}
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module go.thethings.network/lorawan-application-payload
 
-go 1.16
+go 1.17

--- a/wifi.go
+++ b/wifi.go
@@ -1,0 +1,101 @@
+// Copyright © 2022 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package apppayload
+
+import (
+	"encoding/hex"
+	"strings"
+)
+
+// AccessPoint is the signal description of a particular WiFi
+// access point.
+type AccessPoint struct {
+	BSSID [6]byte
+	RSSI  float64
+}
+
+// parseBSSID parses the provided string form hexadecimal BSSID
+// into a [6]byte. Separators such as - and : are removed before
+// the conversion takes place, and the conversion is case insensitive.
+func parseBSSID(s string) ([6]byte, bool) {
+	s = strings.ReplaceAll(s, "-", "")
+	s = strings.ReplaceAll(s, ":", "")
+	bs, err := hex.DecodeString(s)
+	if err != nil {
+		return [6]byte{}, false
+	}
+	if len(bs) != 6 {
+		return [6]byte{}, false
+	}
+	return *(*[6]byte)(bs), true
+}
+
+// InferWiFiAccessPoints uses a predefined set of rules in order to infer the WiFi
+// Access Point information from the provided map.
+//
+// The function will attempt to parse the following structures:
+// - An entry in the map called `access_points` which is an array of objects.
+// The objects are expected to have the AP BSSID inside the `bssid` key
+// and the RSSI in the `rssi` key.
+// - An entry in the map called `wifi` which is an array of objects.
+// The objects are expected to have the AP BSSID inside the `mac` key
+// and the RSSI inside the `rssi` key.
+//
+// The BSSIDs are expected to be in hexadecimal format. Separators such as
+// - and : are stripped before the BSSID is parsed.
+//
+// All numeric values are assumed to be float64.
+//
+// If no access points can be inferred, this function returns false.
+func InferWiFiAccessPoints(m map[string]interface{}) ([]AccessPoint, bool) {
+	if len(m) == 0 {
+		return nil, false
+	}
+
+outer:
+	for apKey, format := range map[string]struct {
+		bssidKey string
+		rssiKey  string
+	}{
+		"access_points": {
+			bssidKey: "bssid",
+			rssiKey:  "rssi",
+		},
+		"wifi": {
+			bssidKey: "mac",
+			rssiKey:  "rssi",
+		},
+	} {
+		accessPoints, ok := m[apKey].([]interface{})
+		if !ok {
+			continue
+		}
+		points := []AccessPoint{}
+		for _, ap := range accessPoints {
+			ap, ok := ap.(map[string]interface{})
+			if !ok {
+				continue outer
+			}
+			bssidStr, ok := ap[format.bssidKey].(string)
+			if !ok {
+				continue outer
+			}
+			bssid, ok := parseBSSID(bssidStr)
+			if !ok {
+				continue outer
+			}
+			rssi, ok := ap[format.rssiKey].(float64)
+			if !ok {
+				continue outer
+			}
+			points = append(points, AccessPoint{
+				BSSID: bssid,
+				RSSI:  rssi,
+			})
+		}
+		return points, true
+	}
+
+	return nil, false
+}

--- a/wifi_test.go
+++ b/wifi_test.go
@@ -1,0 +1,149 @@
+// Copyright © 2021 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package apppayload_test
+
+import (
+	"reflect"
+	"testing"
+
+	apppayload "go.thethings.network/lorawan-application-payload"
+)
+
+func TestWiFiInference(t *testing.T) {
+	for _, tc := range []struct {
+		Name   string
+		Input  map[string]interface{}
+		Output []apppayload.AccessPoint
+		Ok     bool
+	}{
+		{
+			Name: "MalformedBSSID",
+			Input: map[string]interface{}{
+				"access_points": []interface{}{
+					map[string]interface{}{
+						"bssid": "14:60:80:9a:19:58t",
+						"rssi":  -20.0,
+					},
+					map[string]interface{}{
+						"bssid": "fc:f5:28:7b:07:e5",
+						"rssi":  -80.0,
+					},
+				},
+			},
+			Ok: false,
+		},
+		{
+			Name: "MissingBSSID",
+			Input: map[string]interface{}{
+				"access_points": []interface{}{
+					map[string]interface{}{
+						"rssi": -20.0,
+					},
+					map[string]interface{}{
+						"bssid": "fc:f5:28:7b:07:e5",
+						"rssi":  -80.0,
+					},
+				},
+			},
+			Ok: false,
+		},
+		{
+			Name: "MissingRSSI",
+			Input: map[string]interface{}{
+				"access_points": []interface{}{
+					map[string]interface{}{
+						"bssid": "14:60:80:9a:19:58",
+						"rssi":  -20.0,
+					},
+					map[string]interface{}{
+						"bssid": "fc:f5:28:7b:07:e5",
+					},
+				},
+			},
+			Ok: false,
+		},
+		{
+			Name: "Colon",
+			Input: map[string]interface{}{
+				"access_points": []interface{}{
+					map[string]interface{}{
+						"bssid": "14:60:80:9a:19:58",
+						"rssi":  -20.0,
+					},
+					map[string]interface{}{
+						"bssid": "fc:f5:28:7b:07:e5",
+						"rssi":  -80.0,
+					},
+				},
+			},
+			Output: []apppayload.AccessPoint{
+				{
+					BSSID: [6]byte{0x14, 0x60, 0x80, 0x9a, 0x19, 0x58},
+					RSSI:  -20.0,
+				},
+				{
+					BSSID: [6]byte{0xfc, 0xf5, 0x28, 0x7b, 0x07, 0xe5},
+					RSSI:  -80.0,
+				},
+			},
+			Ok: true,
+		},
+		{
+			Name: "Dash",
+			Input: map[string]interface{}{
+				"access_points": []interface{}{
+					map[string]interface{}{
+						"bssid": "15-61-81-9b-1a-59",
+						"rssi":  -21.1,
+					},
+					map[string]interface{}{
+						"bssid": "fd-f6-29-7c-09-e6",
+						"rssi":  -81.1,
+					},
+				},
+			},
+			Output: []apppayload.AccessPoint{
+				{
+					BSSID: [6]byte{0x15, 0x61, 0x81, 0x9b, 0x1a, 0x59},
+					RSSI:  -21.1,
+				},
+				{
+					BSSID: [6]byte{0xfd, 0xf6, 0x29, 0x7c, 0x09, 0xe6},
+					RSSI:  -81.1,
+				},
+			},
+			Ok: true,
+		},
+		{
+			Name: "FormatB",
+			Input: map[string]interface{}{
+				"wifi": []interface{}{
+					map[string]interface{}{
+						"mac":  "a0b3ccd358e6",
+						"rssi": -92.0,
+					},
+				},
+			},
+			Output: []apppayload.AccessPoint{
+				{
+					BSSID: [6]byte{0xa0, 0xb3, 0xcc, 0xd3, 0x58, 0xe6},
+					RSSI:  -92.0,
+				},
+			},
+			Ok: true,
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			points, ok := apppayload.InferWiFiAccessPoints(tc.Input)
+			if tc.Ok != ok {
+				t.Fatal("Expected access points not found")
+			}
+			if tc.Ok {
+				if !reflect.DeepEqual(tc.Output, points) {
+					t.Fatal("Output mismatch")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
References https://github.com/TheThingsNetwork/lorawan-stack/issues/4630

This PR adds inference code for GNSS payloads and WiFi access points.

The WiFi access points inference is based on WiFi format used by `lorawan-stack`:
https://www.thethingsindustries.com/docs/integrations/lora-cloud/geolocation/#toawifi

To that one, this PR also adds support for the format of the payload exposed by the Yabby Edge tracker:
https://github.com/TheThingsNetwork/lorawan-devices/blob/master/vendor/digital-matter/yabby-edge.js